### PR TITLE
Add required type hints

### DIFF
--- a/src/transform.rs
+++ b/src/transform.rs
@@ -19,8 +19,8 @@ impl<D, T> Transform<T> for [D]
         use dft::{Operation, Plan, Transform};
         use num_traits::{One, Zero};
 
-        let zero = Complex::zero();
-        let one = Complex::one();
+        let zero = Complex::<T>::zero();
+        let one = Complex::<T>::one();
         let two = T::one() + T::one();
         let n = self.len();
         let (modulus, argument) = w.to_polar();


### PR DESCRIPTION
Library was failing to compile on rust 1.47.0, which prevented me from using stochastic. Tiny little type hints resolved the issue, as suggested by the compiler.

Test results:

```
running 6 tests
test forward_complex_small_m ... ok
test forward_real ... ok
test forward_complex_different_a ... ok
test forward_complex_large_m ... ok
test forward_complex ... ok
test forward_complex_different_w ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```